### PR TITLE
Fix ssh url

### DIFF
--- a/vcsurl.go
+++ b/vcsurl.go
@@ -287,7 +287,7 @@ func (v *VCS) remoteUnknownHost(p Protocol) (string, error) {
 // git@github.com:go-git/go-git.git
 // git clone git@bitbucket.org:mcuadros/discovery-rest.git
 func (v *VCS) sshRemote() string {
-	return fmt.Sprintf("git@%s/%s/%s.git", v.Host, v.Username, v.Name)
+	return fmt.Sprintf("git@%s:%s/%s.git", v.Host, v.Username, v.Name)
 }
 
 // https://mcuadros@bitbucket.org/mcuadros/discovery-rest.git


### PR DESCRIPTION
Ssh url uses `:`  instead of `/`  after the host. The comments above the function are correct but the implementation is not