### PR TITLE
Fix ssh remote generation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x]
+        go-version: [1.19.x, 1.20.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/example_test.go
+++ b/example_test.go
@@ -37,18 +37,18 @@ func ExampleParse() {
 	// 1. git github.com/alice/libfoo
 	//    name: libfoo
 	//    host: github.com
-	//    remote: git@github.com/alice/libfoo.git
+	//    remote: git@github.com:alice/libfoo.git
 	// 2. git github.com/bob/libbar
 	//    name: libbar
 	//    host: github.com
-	//    remote: git@github.com/bob/libbar.git
+	//    remote: git@github.com:bob/libbar.git
 	// 3. git gitlab.com/foo/bar
 	//    name: bar
 	//    host: gitlab.com
-	//    remote: git@gitlab.com/foo/bar.git
+	//    remote: git@gitlab.com:foo/bar.git
 	// 4. git github.com/go-enry/go-enry
 	//    name: go-enry
 	//    host: github.com
-	//    remote: git@github.com/go-enry/go-enry.git
+	//    remote: git@github.com:go-enry/go-enry.git
 	//    commit-ish: v2.4.1
 }

--- a/vcsurl.go
+++ b/vcsurl.go
@@ -287,7 +287,7 @@ func (v *VCS) remoteUnknownHost(p Protocol) (string, error) {
 // git@github.com:go-git/go-git.git
 // git clone git@bitbucket.org:mcuadros/discovery-rest.git
 func (v *VCS) sshRemote() string {
-	return fmt.Sprintf("git@%s/%s/%s.git", v.Host, v.Username, v.Name)
+	return fmt.Sprintf("git@%s:%s/%s.git", v.Host, v.Username, v.Name)
 }
 
 // https://mcuadros@bitbucket.org/mcuadros/discovery-rest.git

--- a/vcsurl_test.go
+++ b/vcsurl_test.go
@@ -257,11 +257,11 @@ func TestVCSRemote(t *testing.T) {
 		expected string
 		err      error
 	}{
-		{"https://github.com/foo/bar", vcsurl.SSH, "git@github.com/foo/bar.git", nil},
+		{"https://github.com/foo/bar", vcsurl.SSH, "git@github.com:foo/bar.git", nil},
 		{"https://github.com/foo/bar", vcsurl.HTTPS, "https://github.com/foo/bar.git", nil},
-		{"https://bitbucket.org/foo/bar", vcsurl.SSH, "git@bitbucket.org/foo/bar.git", nil},
+		{"https://bitbucket.org/foo/bar", vcsurl.SSH, "git@bitbucket.org:foo/bar.git", nil},
 		{"https://bitbucket.org/foo/bar", vcsurl.HTTPS, "https://bitbucket.org/foo/bar.git", nil},
-		{"https://gitlab.com/foo/bar", vcsurl.SSH, "git@gitlab.com/foo/bar.git", nil},
+		{"https://gitlab.com/foo/bar", vcsurl.SSH, "git@gitlab.com:foo/bar.git", nil},
 		{"https://gitlab.com/foo/bar", vcsurl.HTTPS, "https://gitlab.com/foo/bar.git", nil},
 		{"git://git.savannah.gnu.org/bash.git", vcsurl.SSH, "", vcsurl.ErrUnsupportedProtocol},
 		{"git://git.savannah.gnu.org/bash.git", vcsurl.HTTPS, "", vcsurl.ErrUnsupportedProtocol},


### PR DESCRIPTION
Previously it was generating this:

        git@github.com/gitsight/go-vcsurl.git

instead of:

        git@github.com:gitsight/go-vcsurl.git

Also upgraded go compiler versions